### PR TITLE
I tried to use RootNode for a Repeating node

### DIFF
--- a/src/main/java/com/oracle/truffle/bf/BFMain.java
+++ b/src/main/java/com/oracle/truffle/bf/BFMain.java
@@ -16,7 +16,10 @@ public class BFMain {
     
     
     public static void main(String[] args) throws IOException {
-        BFImpl[] impls = new BFImpl[]{new BFV0()};
+        BFImpl[] impls = new BFImpl[]{
+            new BFV1(),
+            new BFV0(),
+        };
         String arg = args[0];
         if (arg.equals("-benchmark")) {
             BFBenchmark.benchmark(impls);

--- a/src/main/java/com/oracle/truffle/bf/BFMain.java
+++ b/src/main/java/com/oracle/truffle/bf/BFMain.java
@@ -16,7 +16,7 @@ public class BFMain {
     
     
     public static void main(String[] args) throws IOException {
-        BFImpl[] impls = new BFImpl[]{};
+        BFImpl[] impls = new BFImpl[]{new BFV0()};
         String arg = args[0];
         if (arg.equals("-benchmark")) {
             BFBenchmark.benchmark(impls);

--- a/src/main/java/com/oracle/truffle/bf/BFV0.java
+++ b/src/main/java/com/oracle/truffle/bf/BFV0.java
@@ -1,0 +1,75 @@
+
+package com.oracle.truffle.bf;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Arrays;
+
+
+public class BFV0 extends BFImpl {
+
+    private BFParser.Operation[] operations;
+    private InputStream in;
+    private OutputStream out;
+
+    static class Memory {
+        int[] cells;
+        int index;
+
+        public Memory() {
+            cells = new int[100];
+        }
+
+
+    }
+
+    @Override
+    public void prepare(BFParser.Operation[] operations, InputStream in, OutputStream out) {
+        this.operations = operations;
+        this.in = in;
+        this.out = out;
+    }
+
+    @Override
+    public void run() throws IOException {
+        Memory memory = new Memory();
+        run(memory, operations, false);
+    }
+
+    private void run(Memory memory, BFParser.Operation[] operations, boolean repeat) throws IOException {
+        do {
+            if (repeat && memory.cells[memory.index] == 0) {
+                break;
+            }
+            for (BFParser.Operation operation : operations) {
+                switch (operation.getCode()) {
+                    case DEC:
+                        memory.cells[memory.index]--;
+                        break;
+                    case INC:
+                        memory.cells[memory.index]++;
+                        break;
+                    case LEFT:
+                        memory.index--;
+                        break;
+                    case RIGHT:
+                        if (++memory.index >= memory.cells.length) {
+                            memory.cells = Arrays.copyOf(memory.cells, memory.cells.length * 2);
+                        }
+                        break;
+                    case IN:
+                        memory.cells[memory.index] = in.read();
+                        break;
+                    case OUT:
+                        out.write(memory.cells[memory.index]);
+                        break;
+                    case REPEAT:
+                        BFParser.Repeat r = (BFParser.Repeat) operation;
+                        run(memory, r.getChildren(), true);
+                }
+            }
+        } while (repeat);
+    }
+
+}

--- a/src/main/java/com/oracle/truffle/bf/BFV1.java
+++ b/src/main/java/com/oracle/truffle/bf/BFV1.java
@@ -1,0 +1,146 @@
+
+package com.oracle.truffle.bf;
+
+import com.oracle.truffle.api.RootCallTarget;
+import com.oracle.truffle.api.Truffle;
+import com.oracle.truffle.api.TruffleLanguage;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.nodes.RootNode;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Arrays;
+
+
+public class BFV1 extends BFImpl {
+
+    private BFParser.Operation[] operations;
+    private InputStream in;
+    private OutputStream out;
+    private RootCallTarget program;
+
+    static class Memory {
+        int[] cells;
+        int index;
+        final InputStream in;
+        final OutputStream out;
+
+        public Memory(InputStream in, OutputStream out) {
+            cells = new int[100];
+            this.in = in;
+            this.out = out;
+        }
+
+
+    }
+
+    @Override
+    public void prepare(BFParser.Operation[] operations, InputStream in, OutputStream out) {
+        this.operations = operations;
+        this.in = in;
+        this.out = out;
+        this.program = Truffle.getRuntime().createCallTarget(new BlockNode(TruffleLanguage.class, false, OpNode.convert(operations)));
+    }
+
+    @Override
+    public void run() throws IOException {
+        Memory memory = new Memory(in, out);
+        program.call(memory);
+    }
+
+    private static class BlockNode extends RootNode {
+        private final boolean repeat;
+        @Children
+        private final Node[] nodes;
+
+        public BlockNode(Class<? extends TruffleLanguage> language, boolean repeat, Node[] nodes) {
+            super(language, null, null);
+            this.nodes = nodes;
+            this.repeat = repeat;
+        }
+
+        @Override
+        public Object execute(VirtualFrame vf) {
+            Memory memory = (Memory) vf.getArguments()[0];
+            if (repeat) {
+                for (;;) {
+                    if (repeat && memory.cells[memory.index] == 0) {
+                        break;
+                    }
+                    executeChildren(memory, vf);
+                }
+            } else {
+                executeChildren(memory, vf);
+            }
+            return null;
+        }
+
+        @ExplodeLoop
+        private void executeChildren(Memory memory, VirtualFrame vf) {
+            for (Node n : getChildren()) {
+                if (n instanceof BlockNode) {
+                    ((BlockNode) n).execute(vf);
+                } else {
+                    OpNode op = (OpNode) n;
+                    try {
+                        op.execute(memory);
+                    } catch (IOException ex) {
+                        throw new IllegalStateException(ex);
+                    }
+                }
+            }
+        }
+
+    }
+
+    private static class OpNode extends Node {
+
+        static Node[] convert(BFParser.Operation[] operations) {
+            Node[] arr = new Node[operations.length];
+            for (int i = 0; i < operations.length; i++) {
+                final BFParser.Operation op = operations[i];
+                if (op.getCode() == BFParser.OpCode.REPEAT) {
+                    BFParser.Repeat r = (BFParser.Repeat) op;
+                    arr[i] = new BlockNode(TruffleLanguage.class, true, convert(r.getChildren()));
+                } else {
+                    arr[i] = new OpNode(op.getCode());
+                }
+            }
+            return arr;
+        }
+        private final BFParser.OpCode operation;
+
+        public OpNode(BFParser.OpCode operation) {
+            this.operation = operation;
+        }
+
+        public void execute(Memory memory) throws IOException {
+                switch (operation) {
+                    case DEC:
+                        memory.cells[memory.index]--;
+                        break;
+                    case INC:
+                        memory.cells[memory.index]++;
+                        break;
+                    case LEFT:
+                        memory.index--;
+                        break;
+                    case RIGHT:
+                        if (++memory.index >= memory.cells.length) {
+                            memory.cells = Arrays.copyOf(memory.cells, memory.cells.length * 2);
+                        }
+                        break;
+                    case IN:
+                        memory.cells[memory.index] = memory.in.read();
+                        break;
+                    case OUT:
+                        memory.out.write(memory.cells[memory.index]);
+                        break;
+                    default:
+                        assert false;
+                }
+        }
+    }
+}

--- a/src/main/java/com/oracle/truffle/bf/BFV1.java
+++ b/src/main/java/com/oracle/truffle/bf/BFV1.java
@@ -80,7 +80,7 @@ public class BFV1 extends BFImpl {
 
         @ExplodeLoop
         private void executeChildren(Memory memory, VirtualFrame vf) {
-            for (Node n : getChildren()) {
+            for (Node n : nodes) {
                 if (n instanceof BlockNode) {
                     ((BlockNode) n).execute(vf);
                 } else {

--- a/src/main/java/com/oracle/truffle/bf/BFV1.java
+++ b/src/main/java/com/oracle/truffle/bf/BFV1.java
@@ -1,6 +1,7 @@
 
 package com.oracle.truffle.bf;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.TruffleLanguage;
@@ -133,14 +134,24 @@ public class BFV1 extends BFImpl {
                         }
                         break;
                     case IN:
-                        memory.cells[memory.index] = memory.in.read();
+                        memory.cells[memory.index] = read(memory);
                         break;
                     case OUT:
-                        memory.out.write(memory.cells[memory.index]);
+                        write(memory);
                         break;
                     default:
                         assert false;
                 }
+        }
+
+        @CompilerDirectives.TruffleBoundary
+        private static int read(Memory memory) throws IOException {
+            return memory.in.read();
+        }
+
+        @CompilerDirectives.TruffleBoundary
+        private static void write(Memory memory) throws IOException {
+            memory.out.write(memory.cells[memory.index]);
         }
     }
 }


### PR DESCRIPTION
..but I am getting following error:

``` bash
Benchmarking loop0.bf
      BFV1 : [truffle] opt fail         BlockNode@6d5380c2                                          |Reason jdk.vm.ci.code.BailoutException: Too deep inlining, probably caused by recursive inlining.
== Inlined methods ordered by inlining frequency:
com.oracle.truffle.bf.BFV1$BlockNode.executeChildren(BFV1$Memory, VirtualFrame) [498]
com.oracle.truffle.bf.BFV1$BlockNode.execute(VirtualFrame) [498]
com.oracle.truffle.api.nodes.NodeClassImpl.makeIterator(Node) [1]
com.oracle.truffle.api.nodes.NodeClassImpl$NodeIterator.<init>(NodeClassImpl, Node) [1]
com.oracle.graal.truffle.OptimizedCallTarget.callProxy(VirtualFrame) [1]
com.oracle.graal.truffle.OptimizedCallTarget.callRoot(Object[]) [1]
com.oracle.truffle.api.nodes.NodeClassImpl$NodeIterator.advance() [1]
com.oracle.truffle.api.nodes.Node$3.iterator() [1]

com.oracle.truffle.bf.BFV1$BlockNode.execute(BFV1.java:73)
com.oracle.truffle.bf.BFV1$BlockNode.executeChildren(BFV1.java:85)
com.oracle.truffle.bf.BFV1$BlockNode.execute(BFV1.java:76)
com.oracle.graal.truffle.OptimizedCallTarget.callProxy(OptimizedCallTarget.java:220)
com.oracle.graal.truffle.OptimizedCallTarget.callRoot(OptimizedCallTarget.java:212)
        at com.oracle.graal.replacements.PEGraphDecoder.tooDeepInlining(PEGraphDecoder.java:725)
        at com.oracle.graal.replacements.PEGraphDecoder.doInline(PEGraphDecoder.java:581)
        at com.oracle.graal.replacements.PEGraphDecoder.tryInline(PEGraphDecoder.java:566)
        at com.oracle.graal.replacements.PEGraphDecoder.trySimplifyInvoke(PEGraphDecoder.java:486)
        at com.oracle.graal.replacements.PEGraphDecoder.handleInvoke(PEGraphDecoder.java:460)
        at com.oracle.graal.nodes.GraphDecoder.processNextNode(GraphDecoder.java:550)
        at com.oracle.graal.nodes.GraphDecoder.decode(GraphDecoder.java:393)
        at com.oracle.graal.replacements.PEGraphDecoder.decode(PEGraphDecoder.java:394)
        at com.oracle.graal.truffle.PartialEvaluator.doGraphPE(PartialEvaluator.java:397)
        at com.oracle.graal.truffle.PartialEvaluator.fastPartialEvaluation(PartialEvaluator.java:431)
        at com.oracle.graal.truffle.PartialEvaluator.createGraph(PartialEvaluator.java:172)
        at com.oracle.graal.truffle.TruffleCompiler.compileMethod(TruffleCompiler.java:149)
        at com.oracle.graal.truffle.GraalTruffleRuntime.doCompile0(GraalTruffleRuntime.java:466)
        at com.oracle.graal.truffle.GraalTruffleRuntime.doCompile(GraalTruffleRuntime.java:452)
        at com.oracle.graal.truffle.GraalTruffleRuntime$1.run(GraalTruffleRuntime.java:484)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)
        at com.oracle.graal.compiler.CompilerThread.run(CompilerThread.java:51)
```

I have to admit that for a while I had no idea what is wrong. Now I see it: 4743e4fb3404c351d8f89ff697d7d83fb2070127 - but isn't the `getChildren` method (and maybe `insert`, `adoptChildren` ones) a bit misleading? It shouldn't be used on a fast path, yet it is very visible when coding against the API...
